### PR TITLE
Changing default to be first non-all item in type

### DIFF
--- a/index.php
+++ b/index.php
@@ -76,6 +76,16 @@ foreach ($modinfo->get_sections() as $sectionnum => $section) {
 }
 core_collator::asort($activitytypes);
 
+if(!isset($urlparams['activitytype']) && sizeof($activitytypes) >= 2){
+    $types = array_keys($activitytypes);
+    $activitytype = $types[0];
+    if($activitytype === 'all'){
+        $activitytype = $types[1];
+    }
+    
+    $urlparams['activitytype'] = $activitytype;
+}
+
 // Creating the form.
 $baseurl = new moodle_url('/report/editdates/index.php', array('id' => $id));
 $mform = new report_editdates_form($baseurl, array('modinfo' => $modinfo,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/57fae5f3-ae19-48ed-a4b2-088da99bd637)
This PR simple changes the default to be the first type in the list instead of defaulting to all.

The reasoning for this change is when there is a large amount of dates this page takes a long time to load from PHP, and then the JS crashes the browser trying to process all the dates. Filtering it by default will avoid this, and still give the option to show all which can still be very useful on small courses.

There is no plan for this change to go upstream as the plugin has not been accepting PR's for quite a while and it should be fixed properly so it doesn't crash instead of just patching it like this.